### PR TITLE
Prevent ScrollActivator from rerendering all children

### DIFF
--- a/src/ScrollActivator.js
+++ b/src/ScrollActivator.js
@@ -36,9 +36,12 @@ class ScrollActivator extends React.Component {
   }
 
   handleScroll = e => {
-    this.setState({
-      activatedState: this.props.onScroll(e) ? 'isActivated' : 'isNotActivated'
-    })
+    let activatedState = this.props.onScroll(e)
+      ? 'isActivated'
+      : 'isNotActivated'
+    if (this.state.activatedState != activatedState) {
+      this.setState({ activatedState })
+    }
   }
 
   render() {


### PR DESCRIPTION
## Purpose
`react-scroll-activator` was re-rendering all the children every time a scroll event was fired.

## Approach
I added a conditional to prevent the re-rendering of the children unless the `activatedState` prop changes.

#### Open Questions and Pre-Merge TODOs

## Learning

#### Blog Posts

